### PR TITLE
Fix Display Filters overlapping Navigation Buttons

### DIFF
--- a/MainWindow.axaml
+++ b/MainWindow.axaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="N64RecompLauncher.MainWindow"
+<Window x:Class="N64RecompLauncher.MainWindow"
 		xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:anim="https://github.com/whistyun/AnimatedImage.Avalonia"
@@ -718,8 +718,6 @@
 				<Grid.RowDefinitions>
 					<RowDefinition Height="Auto"/>
 					<RowDefinition Height="*"/>
-					<RowDefinition Height="Auto"/>
-					<RowDefinition Height="Auto"/>
 				</Grid.RowDefinitions>
 
 				<!-- Logo/Header -->
@@ -743,186 +741,196 @@
 							   LetterSpacing="3"
 							   Margin="0,2,0,0"/>
 				</StackPanel>
-
-				<!-- Navigation Buttons -->
-				<StackPanel Grid.Row="1" Margin="12,0" VerticalAlignment="Top">
-					
-					<!-- Continue Button -->
-					<Button x:Name="ContinueButton"
-							Classes="settings"
-							Margin="0,0,0,4"
-							CornerRadius="8"
-							Width="216"
-							Height="64"
-							HorizontalAlignment="Left"
-							Click="ContinueButton_Click"
-							IsVisible="{Binding IsContinueVisible}">
-						<Grid>
-							<asyncImageLoader:AdvancedImage Source="{Binding ContinueGameInfo.DefaultIconUrl}"
-															HorizontalAlignment="Right"
-															Stretch="Uniform"
-															Width="216"
-															Height="64"/>
-							<StackPanel Orientation="Horizontal">
-								<Image Width="32" Height="32" 
-									   Source="avares://N64RecompLauncher/Assets/Continue.png"
-									   Margin="0,0,12,0"/>
-								<TextBlock Text="Continue" 
-										  VerticalAlignment="Center"/>
-							</StackPanel>
-						</Grid>
-					</Button>
-
-					<!-- Manage Games Button -->
-					<Button x:Name="ManageGamesButton"
-							Classes="settings"
-							Margin="0,0,0,4"
-							CornerRadius="8"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="ManageGamesButton_Click">
-						<StackPanel Orientation="Horizontal">
-							<Image Width="32" Height="32" 
-								   Source="avares://N64RecompLauncher/Assets/DefaultGame.png"
-								   Margin="0,0,12,0"/>
-							<TextBlock Text="Manage Games" VerticalAlignment="Center"/>
-						</StackPanel>
-					</Button>
-
-					<!-- Settings Button -->
-					<Button x:Name="SettingsButton"
-							Classes="settings"
-							Margin="0,0,0,4"
-							CornerRadius="8"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="SettingsButton_Click">
-						<StackPanel Orientation="Horizontal">
-							<Image Width="32" Height="32" 
-								   Source="avares://N64RecompLauncher/Assets/Settings.png"
-								   Margin="0,0,12,0"/>
-							<TextBlock Text="Settings" VerticalAlignment="Center"/>
-						</StackPanel>
-					</Button>
-
-					<!-- Check for Updates Button -->
-					<Button x:Name="CheckForUpdatesButton"
-							Classes="settings"
-							Margin="0,0,0,4"
-							CornerRadius="8"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="CheckforUpdates_Click">
-						<StackPanel Orientation="Horizontal">
-							<Image Width="32" Height="32" 
-								   Source="avares://N64RecompLauncher/Assets/CheckForUpdates.png"
-								   Margin="0,0,12,0"/>
-							<TextBlock Text="Check for Updates" VerticalAlignment="Center"/>
-						</StackPanel>
-					</Button>
-				</StackPanel>
-
-				<!-- Display Filters -->
-				<StackPanel Grid.Row="2" Margin="12,4,12,4">
-
-					<Border Height="1" Background="{DynamicResource ThemeBorder}" Margin="-12,0,-12,15"/>
-					
-					<TextBlock Text="DISPLAY FILTERS"
-							   FontSize="10"
-							   FontWeight="Bold"
-							   Foreground="{DynamicResource ThemeText}"
-							   LetterSpacing="1"
-							   Margin="12,0,0,4"/>
-					
-					<Button x:Name="UnhideAllGamesButton"
-							Classes="settings"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="UnhideAllGamesButton_Click">
-						<TextBlock Text="All Games"/>
-					</Button>
-
-					<Button x:Name="HideNonInstalledButton"
-							Classes="settings"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="HideNonInstalledButton_Click">
-						<TextBlock Text="Installed Only"/>
-					</Button>
-
-					<Button x:Name="HideNonStableButton"
-							Classes="settings"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="HideNonStableButton_Click"
-							IsVisible="{Binding ShowExperimentalGames}">
-						<TextBlock Text="Stable Only"/>
-					</Button>
-
-					<Button x:Name="OnlyExperimentalGamesButton"
-							Classes="settings"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="OnlyExperimentalGamesButton_Click"
-							IsVisible="{Binding ShowExperimentalGames}">
-						<TextBlock Text="Experimental Only"/>
-					</Button>
-
-					<Button x:Name="OnlyCustomGamesButton"
-							Classes="settings"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="OnlyCustomGamesButton_Click"
-							IsVisible="{Binding ShowCustomGames}">
-						<TextBlock Text="Custom Games Only"/>
-					</Button>
-
-					<Button x:Name="OnlyN64RecompGamesButton"
-							Classes="settings"
-							Width="216"
-							HorizontalAlignment="Left"
-							Click="OnlyN64RecompGamesButton_Click"
-							IsVisible="{Binding ShowCustomGames}">
-						<TextBlock Text="N64Recomp Only"/>
-					</Button>
-				</StackPanel>
 				
-				<!-- Footer Links -->
-				<StackPanel Grid.Row="3" Margin="12,4,12,4">
-					<Border Height="1" Background="{DynamicResource ThemeBorder}" Margin="-12,0,-12,15"/>
-					<Button Classes="iconbutton"
-							Width="216"
-							Height="44"
-							HorizontalAlignment="Left"
-							Click="DiscordButton_Click">
-						<StackPanel Orientation="Horizontal" Margin="12,0">
-							<Image Width="32" Height="32" 
-								   Source="avares://N64RecompLauncher/Assets/Discord.png"
-								   Margin="0,0,12,0"/>
-							<TextBlock Text="Discord" 
-									   Foreground="{DynamicResource ThemeTextSecondary}"
-									   FontSize="14"
-									   FontWeight="Medium"
-									   VerticalAlignment="Center"/>
+				<ScrollViewer Grid.Row="1" VerticalScrollBarVisibility="Auto">
+					<Grid Margin="0">
+						<Grid.RowDefinitions>
+							<RowDefinition Height="Auto"/>
+							<RowDefinition Height="Auto"/>
+							<RowDefinition Height="Auto"/>
+						</Grid.RowDefinitions>
+						
+						<!-- Navigation Buttons -->
+						<StackPanel Grid.Row="0" Margin="12,0" VerticalAlignment="Top">
+					
+							<!-- Continue Button -->
+							<Button x:Name="ContinueButton"
+									Classes="settings"
+									Margin="0,0,0,4"
+									CornerRadius="8"
+									Width="216"
+									Height="64"
+									HorizontalAlignment="Left"
+									Click="ContinueButton_Click"
+									IsVisible="{Binding IsContinueVisible}">
+								<Grid>
+									<asyncImageLoader:AdvancedImage Source="{Binding ContinueGameInfo.DefaultIconUrl}"
+																	HorizontalAlignment="Right"
+																	Stretch="Uniform"
+																	Width="216"
+																	Height="64"/>
+									<StackPanel Orientation="Horizontal">
+										<Image Width="32" Height="32" 
+											   Source="avares://N64RecompLauncher/Assets/Continue.png"
+											   Margin="0,0,12,0"/>
+										<TextBlock Text="Continue" 
+												  VerticalAlignment="Center"/>
+									</StackPanel>
+								</Grid>
+							</Button>
+
+							<!-- Manage Games Button -->
+							<Button x:Name="ManageGamesButton"
+									Classes="settings"
+									Margin="0,0,0,4"
+									CornerRadius="8"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="ManageGamesButton_Click">
+								<StackPanel Orientation="Horizontal">
+									<Image Width="32" Height="32" 
+										   Source="avares://N64RecompLauncher/Assets/DefaultGame.png"
+										   Margin="0,0,12,0"/>
+									<TextBlock Text="Manage Games" VerticalAlignment="Center"/>
+								</StackPanel>
+							</Button>
+
+							<!-- Settings Button -->
+							<Button x:Name="SettingsButton"
+									Classes="settings"
+									Margin="0,0,0,4"
+									CornerRadius="8"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="SettingsButton_Click">
+								<StackPanel Orientation="Horizontal">
+									<Image Width="32" Height="32" 
+										   Source="avares://N64RecompLauncher/Assets/Settings.png"
+										   Margin="0,0,12,0"/>
+									<TextBlock Text="Settings" VerticalAlignment="Center"/>
+								</StackPanel>
+							</Button>
+
+							<!-- Check for Updates Button -->
+							<Button x:Name="CheckForUpdatesButton"
+									Classes="settings"
+									Margin="0,0,0,4"
+									CornerRadius="8"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="CheckforUpdates_Click">
+								<StackPanel Orientation="Horizontal">
+									<Image Width="32" Height="32" 
+										   Source="avares://N64RecompLauncher/Assets/CheckForUpdates.png"
+										   Margin="0,0,12,0"/>
+									<TextBlock Text="Check for Updates" VerticalAlignment="Center"/>
+								</StackPanel>
+							</Button>
 						</StackPanel>
-					</Button>
-					<Button Classes="iconbutton"
-							Width="216"
-							Height="44"
-							HorizontalAlignment="Left"
-							Click="GithubButton_Click">
-						<StackPanel Orientation="Horizontal" Margin="12,0">
-							<Image Width="32" Height="32" 
-								   Source="avares://N64RecompLauncher/Assets/Github.png"
-								   Margin="0,0,12,0"/>
-							<TextBlock Text="GitHub" 
-									   Foreground="{DynamicResource ThemeTextSecondary}"
-									   FontSize="14"
-									   FontWeight="Medium"
-									   VerticalAlignment="Center"/>
+
+						<!-- Display Filters -->
+						<StackPanel Grid.Row="1" Margin="12,4,12,4">
+
+							<Border Height="1" Background="{DynamicResource ThemeBorder}" Margin="-12,0,-12,15"/>
+					
+							<TextBlock Text="DISPLAY FILTERS"
+									   FontSize="10"
+									   FontWeight="Bold"
+									   Foreground="{DynamicResource ThemeText}"
+									   LetterSpacing="1"
+									   Margin="12,0,0,4"/>
+					
+							<Button x:Name="UnhideAllGamesButton"
+									Classes="settings"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="UnhideAllGamesButton_Click">
+								<TextBlock Text="All Games"/>
+							</Button>
+
+							<Button x:Name="HideNonInstalledButton"
+									Classes="settings"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="HideNonInstalledButton_Click">
+								<TextBlock Text="Installed Only"/>
+							</Button>
+
+							<Button x:Name="HideNonStableButton"
+									Classes="settings"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="HideNonStableButton_Click"
+									IsVisible="{Binding ShowExperimentalGames}">
+								<TextBlock Text="Stable Only"/>
+							</Button>
+
+							<Button x:Name="OnlyExperimentalGamesButton"
+									Classes="settings"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="OnlyExperimentalGamesButton_Click"
+									IsVisible="{Binding ShowExperimentalGames}">
+								<TextBlock Text="Experimental Only"/>
+							</Button>
+
+							<Button x:Name="OnlyCustomGamesButton"
+									Classes="settings"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="OnlyCustomGamesButton_Click"
+									IsVisible="{Binding ShowCustomGames}">
+								<TextBlock Text="Custom Games Only"/>
+							</Button>
+
+							<Button x:Name="OnlyN64RecompGamesButton"
+									Classes="settings"
+									Width="216"
+									HorizontalAlignment="Left"
+									Click="OnlyN64RecompGamesButton_Click"
+									IsVisible="{Binding ShowCustomGames}">
+								<TextBlock Text="N64Recomp Only"/>
+							</Button>
 						</StackPanel>
-					</Button>
-				</StackPanel>
+				
+						<!-- Footer Links -->
+						<StackPanel Grid.Row="2" Margin="12,4,12,4">
+							<Border Height="1" Background="{DynamicResource ThemeBorder}" Margin="-12,0,-12,15"/>
+							<Button Classes="iconbutton"
+									Width="216"
+									Height="44"
+									HorizontalAlignment="Left"
+									Click="DiscordButton_Click">
+								<StackPanel Orientation="Horizontal" Margin="12,0">
+									<Image Width="32" Height="32" 
+										   Source="avares://N64RecompLauncher/Assets/Discord.png"
+										   Margin="0,0,12,0"/>
+									<TextBlock Text="Discord" 
+											   Foreground="{DynamicResource ThemeTextSecondary}"
+											   FontSize="14"
+											   FontWeight="Medium"
+											   VerticalAlignment="Center"/>
+								</StackPanel>
+							</Button>
+							<Button Classes="iconbutton"
+									Width="216"
+									Height="44"
+									HorizontalAlignment="Left"
+									Click="GithubButton_Click">
+								<StackPanel Orientation="Horizontal" Margin="12,0">
+									<Image Width="32" Height="32" 
+										   Source="avares://N64RecompLauncher/Assets/Github.png"
+										   Margin="0,0,12,0"/>
+									<TextBlock Text="GitHub" 
+											   Foreground="{DynamicResource ThemeTextSecondary}"
+											   FontSize="14"
+											   FontWeight="Medium"
+											   VerticalAlignment="Center"/>
+								</StackPanel>
+							</Button>
+						</StackPanel>
+					</Grid>
+				</ScrollViewer>
 			</Grid>
 		</Border>
 


### PR DESCRIPTION
Fixes an overlap issue where the Display Filters section is drawn on top of the Navigation buttons if the window is too small.

Additionally wraps the Navigation Buttons, Display Filters, and Footer Links in a ScrollViewer to allow these section to be scroll through and viewed when the window is too small.

Fixes #44 