### PR TITLE
Fix: Prevent CLI from exiting prematurely during async launch tasks o…

### DIFF
--- a/Models/GameInfo.cs
+++ b/Models/GameInfo.cs
@@ -1,4 +1,4 @@
-﻿using Avalonia;
+using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Layout;
@@ -526,6 +526,15 @@ namespace N64RecompLauncher.Models
                     }
 
                     await messageBox.ShowDialog(desktop.MainWindow);
+                }
+                else
+                {
+                    Console.WriteLine();
+                    Console.ForegroundColor = ConsoleColor.Red;
+                    Console.WriteLine($"ERROR: {title}");
+                    Console.ResetColor();
+                    Console.WriteLine(message);
+                    Console.WriteLine();
                 }
             });
         }
@@ -1137,7 +1146,7 @@ namespace N64RecompLauncher.Models
                         File.Create(portableFilePath).Close();
                     }
 
-                    Launch(gamesFolder);
+                    await LaunchAsync(gamesFolder);
                     break;
             }
         }
@@ -2460,7 +2469,7 @@ namespace N64RecompLauncher.Models
             }
         }
 
-        private async void Launch(string gamesFolder)
+        private async Task LaunchAsync(string gamesFolder)
         {
             if (string.IsNullOrEmpty(FolderName))
             {

--- a/Services/CLIHandler.cs
+++ b/Services/CLIHandler.cs
@@ -1,4 +1,4 @@
-﻿using N64RecompLauncher.Models;
+using N64RecompLauncher.Models;
 using N64RecompLauncher.Services;
 using System;
 using System.ComponentModel;
@@ -397,7 +397,11 @@ namespace N64RecompLauncher
                     executables = GameInfo.GetExecutableCandidates(gamePath, SearchOption.AllDirectories, out _);
                 }
 
-                if (executables.Count > 1)
+                if (executables.Count == 0)
+                {
+                    return PrintError($"No executable found for {game.Name} in {gamePath}.\nThe game may not have installed correctly, or it's an unsupported format.");
+                }
+                else if (executables.Count > 1)
                 {
                     WriteColor($"⚠ Multiple executables found for {game.Name}.", ColorWarning);
                     Console.WriteLine();


### PR DESCRIPTION
**Description**
This PR fixes two critical issues that completely prevented games from successfully launching via the Command Line Interface (e.g. `./N64RecompLauncher --run "Game"`), particularly on Linux/Steam Deck hardware.

**Root Causes & Fixes:**
1. **Async Void Race Condition in `GameInfo.cs`**:
   - **The Bug:** `Launch()` was using an `async void` signature. On Linux, when attempting to launch natively extension-less binaries, it yields to sequentially run a background `chmod +x` command to grant execution permissions. Because `Launch` couldn't be awaited, the `CLIHandler` assumed execution was completed instantly and terminated the program, gracefully killing the background thread before `chmod` could finish or the game could spawn.
   - **The Fix:** Changed `Launch()` to return a `Task` (`LaunchAsync()`) and `await`ed it inside `PerformActionAsync()`, forcing the CLI to stay alive long enough to properly spawn the game process.

2. **Unhandled Headless Error Reporting (`GameInfo.cs` & `CLIHandler.cs`)**:
   - **The Bug:** `ShowMessageBoxAsync` was hardcoded exclusively for UI workflows (`MainWindow != null`). When running headlessly via CLI, any internal launch errors (like failing to discover a required Wine/Proton runner for a Windows `.exe` on Linux) would silently vanish without alerting the user. Additionally, `CLIHandler` lacked a safety check for when zero valid executables were located.
   - **The Fix:** Added an `else` block to pipe `ShowMessageBoxAsync` contents to standard `Console.WriteLine()` when no `MainWindow` is present. Additionally added an `executables.Count == 0` catch inside the CLI flow to print an informative error log rather than attempting a ghost execution.

**Testing:**
Cross-compiled via `dotnet publish -r linux-x64` and explicitly validated extension-less game launching logic—as well as accurate headless error reporting—purely via terminal on a Steam Deck running SteamOS.