### PR TITLE
feat: Batocera proton detection

### DIFF
--- a/.github/workflows/dotnet-desktop.yml
+++ b/.github/workflows/dotnet-desktop.yml
@@ -8,36 +8,36 @@ on:
   workflow_dispatch:
 
 jobs:
-  build-windows:
-    runs-on: windows-latest
+  # build-windows:
+  #   runs-on: windows-latest
     
-    env:
-      Solution_Name: N64RecompLauncher.sln
+  #   env:
+  #     Solution_Name: N64RecompLauncher.sln
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: recursive
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       fetch-depth: 0
+  #       submodules: recursive
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
+  #   - name: Setup .NET
+  #     uses: actions/setup-dotnet@v4
+  #     with:
+  #       dotnet-version: 9.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore N64RecompLauncher.sln
+  #   - name: Restore dependencies
+  #     run: dotnet restore N64RecompLauncher.sln
 
-    - name: Publish Windows x64
-      run: dotnet publish N64RecompLauncher.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false -o publish/win-x64
+  #   - name: Publish Windows x64
+  #     run: dotnet publish N64RecompLauncher.csproj -c Release -r win-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false -o publish/win-x64
 
-    - name: Upload Windows x64
-      uses: actions/upload-artifact@v4
-      with:
-        name: N64RecompLauncher-Windows-x64
-        path: publish/win-x64
-        retention-days: 14
+  #   - name: Upload Windows x64
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: N64RecompLauncher-Windows-x64
+  #       path: publish/win-x64
+  #       retention-days: 14
 
   build-linux:
     runs-on: ubuntu-latest
@@ -63,8 +63,8 @@ jobs:
     - name: Publish Linux x64
       run: dotnet publish N64RecompLauncher.csproj -c Release -r linux-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false -o publish/linux-x64
 
-    - name: Publish Linux ARM64
-      run: dotnet publish N64RecompLauncher.csproj -c Release -r linux-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false -o publish/linux-arm64
+    # - name: Publish Linux ARM64
+    #   run: dotnet publish N64RecompLauncher.csproj -c Release -r linux-arm64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false -o publish/linux-arm64
 
     - name: Upload Linux x64
       uses: actions/upload-artifact@v4
@@ -73,79 +73,79 @@ jobs:
         path: publish/linux-x64
         retention-days: 14
 
-    - name: Upload Linux ARM64
-      uses: actions/upload-artifact@v4
-      with:
-        name: N64RecompLauncher-Linux-ARM64
-        path: publish/linux-arm64
-        retention-days: 14
+    # - name: Upload Linux ARM64
+    #   uses: actions/upload-artifact@v4
+    #   with:
+    #     name: N64RecompLauncher-Linux-ARM64
+    #     path: publish/linux-arm64
+    #     retention-days: 14
 
-  build-macos:
-    runs-on: macos-latest
+  # build-macos:
+  #   runs-on: macos-latest
     
-    env:
-      Solution_Name: N64RecompLauncher.sln
-      App_Name: N64RecompLauncher
+  #   env:
+  #     Solution_Name: N64RecompLauncher.sln
+  #     App_Name: N64RecompLauncher
 
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        submodules: recursive
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@v4
+  #     with:
+  #       fetch-depth: 0
+  #       submodules: recursive
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v4
-      with:
-        dotnet-version: 9.0.x
+  #   - name: Setup .NET
+  #     uses: actions/setup-dotnet@v4
+  #     with:
+  #       dotnet-version: 9.0.x
 
-    - name: Restore dependencies
-      run: dotnet restore N64RecompLauncher.sln
+  #   - name: Restore dependencies
+  #     run: dotnet restore N64RecompLauncher.sln
 
-    - name: Publish macOS x64
-      run: dotnet publish N64RecompLauncher.csproj -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false -o publish/osx-x64
+  #   - name: Publish macOS x64
+  #     run: dotnet publish N64RecompLauncher.csproj -c Release -r osx-x64 --self-contained true -p:PublishSingleFile=true -p:PublishTrimmed=false -o publish/osx-x64
 
-    - name: Create macOS .app bundle
-      run: |
-        APP_BUNDLE="publish/${{ env.App_Name }}.app"
-        mkdir -p "$APP_BUNDLE/Contents/MacOS"
-        mkdir -p "$APP_BUNDLE/Contents/Resources"
+  #   - name: Create macOS .app bundle
+  #     run: |
+  #       APP_BUNDLE="publish/${{ env.App_Name }}.app"
+  #       mkdir -p "$APP_BUNDLE/Contents/MacOS"
+  #       mkdir -p "$APP_BUNDLE/Contents/Resources"
         
-        # Copy all published files to the app bundle
-        cp -r publish/osx-x64/* "$APP_BUNDLE/Contents/MacOS/"
+  #       # Copy all published files to the app bundle
+  #       cp -r publish/osx-x64/* "$APP_BUNDLE/Contents/MacOS/"
         
-        # Make the executable... executable
-        chmod +x "$APP_BUNDLE/Contents/MacOS/${{ env.App_Name }}"
+  #       # Make the executable... executable
+  #       chmod +x "$APP_BUNDLE/Contents/MacOS/${{ env.App_Name }}"
         
-        # Create Info.plist
-        cat > "$APP_BUNDLE/Contents/Info.plist" << EOF
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-            <key>CFBundleExecutable</key>
-            <string>${{ env.App_Name }}</string>
-            <key>CFBundleIdentifier</key>
-            <string>com.yourcompany.n64recomp</string>
-            <key>CFBundleName</key>
-            <string>${{ env.App_Name }}</string>
-            <key>CFBundleVersion</key>
-            <string>1.0.0</string>
-            <key>CFBundleShortVersionString</key>
-            <string>1.0.0</string>
-            <key>CFBundlePackageType</key>
-            <string>APPL</string>
-            <key>LSMinimumSystemVersion</key>
-            <string>10.15</string>
-            <key>NSHighResolutionCapable</key>
-            <true/>
-        </dict>
-        </plist>
-        EOF
+  #       # Create Info.plist
+  #       cat > "$APP_BUNDLE/Contents/Info.plist" << EOF
+  #       <?xml version="1.0" encoding="UTF-8"?>
+  #       <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+  #       <plist version="1.0">
+  #       <dict>
+  #           <key>CFBundleExecutable</key>
+  #           <string>${{ env.App_Name }}</string>
+  #           <key>CFBundleIdentifier</key>
+  #           <string>com.yourcompany.n64recomp</string>
+  #           <key>CFBundleName</key>
+  #           <string>${{ env.App_Name }}</string>
+  #           <key>CFBundleVersion</key>
+  #           <string>1.0.0</string>
+  #           <key>CFBundleShortVersionString</key>
+  #           <string>1.0.0</string>
+  #           <key>CFBundlePackageType</key>
+  #           <string>APPL</string>
+  #           <key>LSMinimumSystemVersion</key>
+  #           <string>10.15</string>
+  #           <key>NSHighResolutionCapable</key>
+  #           <true/>
+  #       </dict>
+  #       </plist>
+  #       EOF
 
-    - name: Upload macOS x64
-      uses: actions/upload-artifact@v4
-      with:
-        name: N64RecompLauncher-macOS-x64
-        path: publish/${{ env.App_Name }}.app
-        retention-days: 14
+  #   - name: Upload macOS x64
+  #     uses: actions/upload-artifact@v4
+  #     with:
+  #       name: N64RecompLauncher-macOS-x64
+  #       path: publish/${{ env.App_Name }}.app
+  #       retention-days: 14

--- a/Models/GameInfo.cs
+++ b/Models/GameInfo.cs
@@ -2429,7 +2429,9 @@ namespace N64RecompLauncher.Models
                 Path.Combine(homePath, ".steam", "root"),
                 Path.Combine(homePath, ".steam", "steam"),
                 Path.Combine(homePath, ".local", "share", "Steam"),
-                Path.Combine(homePath, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam")
+                Path.Combine(homePath, ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam"),
+                // Batocera Linux stores Flatpak app data under /userdata/saves/flatpak/data rather than $HOME/.var
+                Path.Combine("/userdata", "saves", "flatpak", "data", ".var", "app", "com.valvesoftware.Steam", ".local", "share", "Steam")
             };
 
             return steamRoots


### PR DESCRIPTION
Adds Batocera Linux support for Proton auto-detection. Batocera stores Flatpak app data at `/userdata/saves/flatpak/data/` rather than the standard `$HOME/.var/app/` path, so the existing Flatpak Steam path check was resolving to the wrong location.

Adds the Batocera-specific absolute path to the Steam root scan so that Proton installations under Flatpak Steam are correctly detected.

This Pull Request is just so I have a build that I can test on my Batocera machine.