### PR TITLE
fix: store GitHub API token encrypted via SecretStore (AES-256-GCM)

### DIFF
--- a/MainWindow.axaml.cs
+++ b/MainWindow.axaml.cs
@@ -1892,7 +1892,10 @@ namespace GithubLauncher
                 }
 
                 if (GitHubTokenTextBox != null)
+                {
                     GitHubTokenTextBox.Text = _settings.GitHubApiToken;
+                    GitHubTokenTextBox.PasswordChar = '*';
+                }
 
                 if (GamePathTextBox != null)
                     GamePathTextBox.Text = _settings.AppsPath;

--- a/Models/GameInfo.cs
+++ b/Models/GameInfo.cs
@@ -1243,8 +1243,7 @@ namespace GithubLauncher.Models
         {
             try
             {
-                var settings = AppSettings.Load();
-                return settings?.GitHubApiToken ?? string.Empty;
+                return SecretStore.ReadToken();
             }
             catch
             {

--- a/Services/AppSettings.cs
+++ b/Services/AppSettings.cs
@@ -23,7 +23,12 @@ namespace GithubLauncher
         public List<string> HiddenApps { get; set; } = new List<string>();
         public List<string> ManuallyHiddenApps { get; set; } = new List<string>();
         public string AppsPath { get; set; } = string.Empty;
-        public string GitHubApiToken { get; set; } = string.Empty;
+        [System.Text.Json.Serialization.JsonIgnore]
+        public string GitHubApiToken
+        {
+            get => SecretStore.ReadToken();
+            set => SecretStore.WriteToken(value);
+        }
         public string SortBy { get; set; } = "LastPlayed";
         public bool StartFullscreen { get; set; } = false;
         public bool CloseAfterLaunch {  get; set; } = false;

--- a/Services/SecretStore.cs
+++ b/Services/SecretStore.cs
@@ -1,0 +1,180 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace GithubLauncher
+{
+    /// <summary>
+    /// Securely stores the GitHub API token using AES-256-GCM encryption.
+    /// The encrypted blob is stored outside the app directory with restricted
+    /// file permissions (0600 on Unix, inherited ACL on Windows).
+    /// This prevents casual token theft via settings.json exposure.
+    /// </summary>
+    public static class SecretStore
+    {
+        private const string DataDirName = "GithubLauncher";
+        private const string TokenFileName = "github_token.enc";
+        private const string KeyFileName = "github_token.key";
+
+        private static readonly string DataDir;
+        private static readonly string TokenPath;
+        private static readonly string KeyPath;
+
+        private static byte[]? _cachedKey;
+        private static string? _cachedToken;
+
+        static SecretStore()
+        {
+            var baseDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            if (string.IsNullOrEmpty(baseDir))
+                baseDir = Path.Combine(
+                    Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                    ".local", "share");
+            DataDir = Path.Combine(baseDir, DataDirName);
+            TokenPath = Path.Combine(DataDir, TokenFileName);
+            KeyPath = Path.Combine(DataDir, KeyFileName);
+        }
+
+        public static string ReadToken()
+        {
+            if (_cachedToken != null)
+                return _cachedToken;
+
+            try
+            {
+                if (!File.Exists(TokenPath) || !File.Exists(KeyPath))
+                    return string.Empty;
+
+                byte[] key = File.ReadAllBytes(KeyPath);
+                byte[] ciphertext = File.ReadAllBytes(TokenPath);
+
+                string? token = Decrypt(ciphertext, key);
+                _cachedToken = token ?? string.Empty;
+                return _cachedToken;
+            }
+            catch
+            {
+                return string.Empty;
+            }
+        }
+
+        public static void WriteToken(string? token)
+        {
+            try
+            {
+                Directory.CreateDirectory(DataDir);
+
+                if (string.IsNullOrEmpty(token))
+                {
+                    if (File.Exists(TokenPath)) File.Delete(TokenPath);
+                    if (File.Exists(KeyPath)) File.Delete(KeyPath);
+                    _cachedToken = string.Empty;
+                    return;
+                }
+
+                byte[] key = GenerateOrLoadKey();
+                byte[] ciphertext = Encrypt(token, key);
+                File.WriteAllBytes(TokenPath, ciphertext);
+                SetRestrictedPermissions(TokenPath);
+
+                _cachedToken = token;
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SecretStore: failed to write token: {ex.Message}");
+                throw;
+            }
+        }
+
+        public static void ClearToken()
+        {
+            WriteToken(null);
+        }
+
+        public static bool HasToken()
+        {
+            return !string.IsNullOrEmpty(ReadToken());
+        }
+
+        private static byte[] GenerateOrLoadKey()
+        {
+            if (_cachedKey != null)
+                return _cachedKey;
+
+            if (File.Exists(KeyPath))
+            {
+                _cachedKey = File.ReadAllBytes(KeyPath);
+                if (_cachedKey.Length == 32)
+                    return _cachedKey;
+            }
+
+            byte[] key = RandomNumberGenerator.GetBytes(32);
+            File.WriteAllBytes(KeyPath, key);
+            SetRestrictedPermissions(KeyPath);
+            _cachedKey = key;
+            return key;
+        }
+
+        private static byte[] Encrypt(string plaintext, byte[] key)
+        {
+            byte[] nonce = RandomNumberGenerator.GetBytes(12);
+            byte[] plainBytes = Encoding.UTF8.GetBytes(plaintext);
+            byte[] ciphertext = new byte[nonce.Length + plainBytes.Length + 16];
+
+            using var aes = new AesGcm(key);
+            Array.Copy(nonce, 0, ciphertext, 0, nonce.Length);
+            aes.Encrypt(nonce, plainBytes,
+                ciphertext.AsSpan(nonce.Length, plainBytes.Length),
+                ciphertext.AsSpan(nonce.Length + plainBytes.Length, 16));
+
+            return ciphertext;
+        }
+
+        private static string? Decrypt(byte[] ciphertext, byte[] key)
+        {
+            try
+            {
+                const int nonceSize = 12;
+                const int tagSize = 16;
+
+                if (ciphertext.Length < nonceSize + tagSize)
+                    return null;
+
+                byte[] nonce = new byte[nonceSize];
+                byte[] tag = new byte[tagSize];
+                int dataLen = ciphertext.Length - nonceSize - tagSize;
+                byte[] data = new byte[dataLen];
+
+                Array.Copy(ciphertext, 0, nonce, 0, nonceSize);
+                Array.Copy(ciphertext, nonceSize, data, 0, dataLen);
+                Array.Copy(ciphertext, nonceSize + dataLen, tag, 0, tagSize);
+
+                byte[] plainBytes = new byte[dataLen];
+                using var aes = new AesGcm(key);
+                aes.Decrypt(nonce, data, tag, plainBytes);
+
+                return Encoding.UTF8.GetString(plainBytes);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static void SetRestrictedPermissions(string path)
+        {
+            try
+            {
+                if (OperatingSystem.IsWindows())
+                    return;
+                File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite);
+            }
+            catch (PlatformNotSupportedException) { }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"SecretStore: failed to set permissions on {path}: {ex.Message}");
+            }
+        }
+    }
+}


### PR DESCRIPTION
## The Problem

The GitHub API token (personal access token) is stored as **plaintext** in `settings.json` alongside the app binary. This means:

- Any process running on the same machine can read the token from disk
- Anyone with file system access to `<app>/settings.json` has full use of the token
- Users who share screenshots of their settings panel inadvertently expose the token (no password masking)
- The token is serialized with the rest of the application settings, so a settings export/share leaks credentials too

The GitHub API token is used to authenticate requests to the GitHub API. With a plaintext token on disk, the credential boundary is reduced to "can this process read a JSON file?" — which is nearly everything on a desktop OS.

## The Fix

### 1. Encrypted token storage (`Services/SecretStore.cs`)

- AES-256-GCM encryption (NIST SP 800-38D) with a **random 32-byte key**
- Ciphertext + key stored at `~/.local/share/GithubLauncher/` outside the app directory
- Unix file permissions set to **0600** (owner read/write only)
- Key auto-generated on first use — if the key file is deleted, a new one is created and the token must be re-entered
- Token is cached in memory for the lifetime of the process — no repeated decryption overhead

### 2. JsonIgnore on AppSettings (`Services/AppSettings.cs`)

- `GitHubApiToken` gains `[System.Text.Json.Serialization.JsonIgnore]` — it is **never serialized** to `settings.json`
- Property getter/setter redirect through `SecretStore.ReadToken()` / `SecretStore.WriteToken()`
- All existing code paths (settings panel, CLI, game manager) continue to work through the property redirect

### 3. Password masking (`MainWindow.axaml.cs`)

- The token input field now uses `PasswordChar = '*'` — the token is masked in the UI
- Token is still editable: typing into the field sets the new value; the clear button still works
- When the settings panel loads, the token is populated from `SecretStore` (decrypted in memory)

### 4. Direct SecretStore access (`Models/GameInfo.cs`)

- `GetGitHubApiToken()` reads directly from `SecretStore.ReadToken()` instead of re-loading `AppSettings.Load()` every call

## Backward Compatibility

- On first launch after this change, any existing token in `settings.json` will be **ignored** (the `[JsonIgnore]` property won't read from JSON)
- Users will need to re-enter their token in the settings UI, which then encrypts it via `SecretStore`
- This is a one-time migration — subsequent launches read from the encrypted store

## Security Trade-offs

- This is **not** OS-native keychain integration (DPAPI on Windows, Keychain on macOS, libsecret on Linux) — that would be a follow-up
- The AES key is stored in a separate file at 0600 permissions, so an attacker who can read `~/.local/share/GithubLauncher/\* ` can decrypt the token. This is still **strictly better** than plaintext in the app directory where any process or user-accessible path can read it
- Memory exposure: the decrypted token lives in the .NET heap for the process lifetime. A memory-dump attack would still recover it — this protects against **disk-level** exposure only